### PR TITLE
Add missing IconProbs

### DIFF
--- a/src/Icon.d.ts
+++ b/src/Icon.d.ts
@@ -1,4 +1,15 @@
 import * as React from 'react'
 import { RMWC } from './Base'
 
-export declare class Icon extends React.Component<RMWC.UseProps<Icon>> {}
+declare namespace Icon {
+    export interface IconProps extends RMWC.UseProps<Icon> {
+        /** Handle multiple methods of embedding an icon. */
+        strategy?: 'auto'|'ligature'|'className'|'url'|'component',
+        /** A className prefix to use when using css font icons that use prefixes, i.e. font-awesome-, ion-, glyphicons- */
+        prefix?: string,
+        /** A base className for the icon namespace, i.e. material-icons */
+        basename?: string
+    }
+}
+
+export declare class Icon extends React.Component<Icon.IconProps> {}


### PR DESCRIPTION
See [here](https://github.com/jamesmfriedman/rmwc/blob/v0.0.1-rc11/src/Icon/index.js#L19) and [here](https://jamesmfriedman.github.io/rmwc/icons).

Website lists all `strategy`, `prefix`, `basename` and `use` as required, but in the examples it seems likes they are not required, therefore I made them optional.