### PR TITLE
Add "body" to DialogProps

### DIFF
--- a/src/Dialog.d.ts
+++ b/src/Dialog.d.ts
@@ -21,6 +21,8 @@ declare namespace Dialog {
         /** Callback for when the Dialog closes. */
         onClose?: (evt: Event) => any,
         // apiRef?: (apiInstance: Object) => any
+        /** Body content for the default Dialog template. */
+        body?: React.ReactNode
     }
 
     export interface DefaultDialogTemplateProps extends React.DOMAttributes<DefaultDialogTemplate>, RMWC.RMWCTagProps {


### PR DESCRIPTION
`body` can be used in `Dialog` as a property. It was not documented in the props section but is used in [Dialogs demo](https://jamesmfriedman.github.io/rmwc/dialogs).

Note: I am experiencing some issues using Dialog with children but that is a separate issue.